### PR TITLE
export authenticateWithConnectionName to JS

### DIFF
--- a/auth0-lock.js
+++ b/auth0-lock.js
@@ -14,6 +14,10 @@ class Auth0Lock {
     }
   }
 
+  hide(callback) {
+    LockModule.hide(callback);
+  }
+
   show(options, callback) {
     LockModule.init(this.lockOptions);
     if (this.nativeIntegrations) {

--- a/objc/A0LockReactModule.m
+++ b/objc/A0LockReactModule.m
@@ -85,6 +85,12 @@ RCT_EXPORT_METHOD(nativeIntegrations:(NSDictionary *)integrations) {
     [lock registerAuthenticators:authenticators];
 }
 
+RCT_EXPORT_METHOD(hide:(RCTResponseSenderBlock)callback) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[A0LockReact sharedInstance] hideWithCallback:callback];
+    });
+}
+
 RCT_EXPORT_METHOD(show:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback) {
     dispatch_async(dispatch_get_main_queue(), ^{
         [[A0LockReact sharedInstance] showWithOptions:options callback:callback];

--- a/objc/core/A0LockReact.h
+++ b/objc/core/A0LockReact.h
@@ -29,6 +29,8 @@ typedef void(^A0LockCallback)(NSArray *parameters);
 
 @property (strong, readonly, nonatomic) A0Lock *lock;
 
+- (void)hideWithCallback:(A0LockCallback)callback;
+
 - (void)showWithOptions:(NSDictionary *)options callback:(A0LockCallback)callback;
 
 - (void)configureLockFromBundle;

--- a/objc/core/A0LockReact.m
+++ b/objc/core/A0LockReact.m
@@ -25,6 +25,11 @@
 #import "A0Token+ReactNative.h"
 #import "A0UserProfile+ReactNative.h"
 
+
+@interface A0LockReact()
+@property (nonatomic, assign) BOOL shown;
+@end
+
 @implementation A0LockReact
 
 + (instancetype)sharedInstance {
@@ -42,6 +47,19 @@
 
 - (void)configureLockWithClientId:(NSString *)clientId domain:(NSString *)domain {
     _lock = [A0Lock newLockWithClientId:clientId domain:domain];
+}
+
+- (void)hideWithCallback:(A0LockCallback)callback {
+    if (self.shown) {
+        if (!self.lock) {
+            callback(@[@"Please configure Lock before using it"]);
+            return;
+        }
+        UIViewController *controller = [[[[UIApplication sharedApplication] windows] firstObject] rootViewController];
+        [controller dismissViewControllerAnimated:YES completion:nil];
+        self.shown = NO;
+    }
+    callback(@[]);
 }
 
 - (void)showWithOptions:(NSDictionary *)options callback:(A0LockCallback)callback {
@@ -78,6 +96,7 @@
         [controller dismissViewControllerAnimated:YES completion:nil];
     };
     void(^dismissBlock)() = ^{
+        self.shown =  NO;
         callback(@[@"Lock was dismissed by the user", [NSNull null], [NSNull null]]);
     };
 
@@ -115,6 +134,7 @@
         lock.onUserDismissBlock = dismissBlock;
         [self.lock presentLockController:lock fromController:controller];
     }
+    self.shown = YES;
 }
 
 - (A0AuthParameters *)authenticationParametersFromOptions:(NSDictionary *)options {


### PR DESCRIPTION
export authenticateWithConnectionName to JS to make it easy to launch a login flow without showing the Lock UI.